### PR TITLE
Update hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -57,7 +57,6 @@
 127.0.0.1 gslb.hpplay.cn
 127.0.0.1 gvod.aiseejapp.atianqi.com
 127.0.0.1 h5.hpplay.com.cn
-127.0.0.1 hotupgrade.hpplay.
 127.0.0.1 hotupgrade.hpplay.cn
 127.0.0.1 hpplay.cdn.cibn.cc
 127.0.0.1 hub5btmain.sandai.net


### PR DESCRIPTION
第60行 127.0.0.1 hotupgrade.hpplay. 错误，少了cn域名，和第61行重复。